### PR TITLE
Tweaks to enable deployment via awsbox

### DIFF
--- a/.awsbox.json
+++ b/.awsbox.json
@@ -1,0 +1,5 @@
+{
+  "processes": [
+    "index.js"
+  ]
+}

--- a/server.js
+++ b/server.js
@@ -7,7 +7,8 @@ var routes = require('./routes');
 var settings = {};
 
 // Create a server with a host and port
-var server = new Hapi.Server('localhost', process.env.PORT || 8000, settings);
+var port = parseInt(process.env.PORT || 8000, 10);
+var server = new Hapi.Server('localhost', port, settings);
 server.addRoutes(routes);
 
 module.exports = server;


### PR DESCRIPTION
This lets us do test deployments with awsbox - the only trick is that hapi demands an integer for the port, so we have to parseInt it ourselves from the env var.
