### PR TITLE
Couchbase install

### DIFF
--- a/.awsbox.json
+++ b/.awsbox.json
@@ -3,6 +3,6 @@
     "index.js"
   ],
   "env": {
-    "CONFIG_FILES": "$HOME/code/config/aws.json,$HOME/config.json"
+    "CONFIG_FILES": "$HOME/code/config/aws.json,$HOME/kvstore.json,$HOME/config.json"
   }
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,9 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 var convict = require('convict');
 
 const AVAILABLE_BACKENDS = ["memory", "couchbase"];
 
 
 var conf = module.exports = convict({
+  env: {
+    doc: "The current node.js environment",
+    default: "production",
+    format: [ "production", "local", "test" ],
+    env: 'NODE_ENV'
+  },
   public_url: {
     format: "url",
     // the real url is set by awsbox
@@ -18,16 +28,21 @@ var conf = module.exports = convict({
     available_backends: {
       doc: "List of available key-value stores",
       default: AVAILABLE_BACKENDS
-    },
-    username: {
-      default: 'Administrator'
+    }
+  },
+  couchbase: {
+    user: {
+      default: 'Administrator',
       env: 'DB_USERNAME'
     },
     password: {
       default: 'password',
       env: 'DB_PASSWORD'
     },
-    bucket: 'picl',
+    bucket: {
+      default: 'picl',
+      env: 'DB_BUCKET'
+    },
     hosts: [ "localhost:8091" ]
   },
   bind_to: {
@@ -56,4 +71,11 @@ if (process.env.CONFIG_FILES) {
   });
 }
 
+if (conf.get('env') === 'test'
+    && conf.get('kvstore.backend') === 'couchbase') {
+  conf.set('couchbase.bucket', 'default');
+}
+
 conf.validate();
+
+console.log('configuration: ', conf.toString());

--- a/lib/config.js
+++ b/lib/config.js
@@ -12,12 +12,23 @@ var conf = module.exports = convict({
   kvstore: {
     backend: {
       format: AVAILABLE_BACKENDS,
-      default: "memory"
+      default: "memory",
+      env: 'DB_BACKEND'
     },
     available_backends: {
       doc: "List of available key-value stores",
       default: AVAILABLE_BACKENDS
-    }
+    },
+    username: {
+      default: 'Administrator'
+      env: 'DB_USERNAME'
+    },
+    password: {
+      default: 'password',
+      env: 'DB_PASSWORD'
+    },
+    bucket: 'picl',
+    hosts: [ "localhost:8091" ]
   },
   bind_to: {
     host: {

--- a/lib/config.js
+++ b/lib/config.js
@@ -23,7 +23,7 @@ var conf = module.exports = convict({
     backend: {
       format: AVAILABLE_BACKENDS,
       default: "memory",
-      env: 'DB_BACKEND'
+      env: 'KVSTORE_BACKEND'
     },
     available_backends: {
       doc: "List of available key-value stores",
@@ -33,15 +33,15 @@ var conf = module.exports = convict({
   couchbase: {
     user: {
       default: 'Administrator',
-      env: 'DB_USERNAME'
+      env: 'KVSTORE_USERNAME'
     },
     password: {
       default: 'password',
-      env: 'DB_PASSWORD'
+      env: 'KVSTORE_PASSWORD'
     },
     bucket: {
       default: 'picl',
-      env: 'DB_BUCKET'
+      env: 'KVSTORE_BUCKET'
     },
     hosts: [ "localhost:8091" ]
   },

--- a/lib/kvstore/couchbase.js
+++ b/lib/kvstore/couchbase.js
@@ -8,26 +8,30 @@
  */
 
 var couchbase = require('couchbase');
+var config = require('../config');
+var Hapi = require('hapi');
 
 
 module.exports = {
 
   connect: function(options, cb) {
+    options = Hapi.utils.merge(options, config.get('couchbase'));
+
     couchbase.connect(options, function(err, bucket) {
-      if(err) { return cb(err); }
+      if (err) return cb(err);
 
       // Following the lead of couchbase node module, this is using closures
       // and simple objects rather than instantiating a prototype connection.
 
       function get(key, cb) {
         bucket.get(key, function(err, value, meta) {
-          if(err) { return cb(err); }
+          if (err) return cb(err);
           cb(null, {value: value, casid: meta.cas});
-        }
+        });
       }
 
       function set(key, value, cb) {
-        bucket.set(key, value, null, function(err) {
+        bucket.set(key, value, {}, function(err) {
           cb(err);
         });
       }
@@ -38,7 +42,7 @@ module.exports = {
         });
       }
 
-      cb(null, {get:get, set:set, cas:cas});
+      cb(null, {get: get, set: set, cas: cas});
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/.bin/mocha -R spec --recursive --timeout 4000 --ignore-leaks",
-    "start": "node index.js",
+    "start": "NODE_ENV=local node index.js",
     "loadtest": "node loadtest/run.js"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "convict": "git://github.com/zaach/node-convict.git#disorderly",
     "async": "0.1.22"
   },
+  "optionalDependencies": {
+    "couchbase": "0.0.11"
+  },
   "devDependencies": {
     "mocha": "1.8.1"
   }

--- a/scripts/aws/install_couchbase.js
+++ b/scripts/aws/install_couchbase.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+var fs = require('fs');
+var path = require('path');
+var child_process = require('child_process');
+
+function uploadScript (host, cb) {
+  var args = [ path.join(__dirname, 'install_couchbase.sh'),
+              'ec2-user@' + host + ':install_couchbase.sh' ];
+              console.log(args);
+  var p = child_process.spawn('scp', args, {'stdio': 'inherit'});
+
+  p.on('exit', function(code, signal) {
+    var err = code || signal;
+    if (err && cb) return cb(err);
+    ssh('sh install_couchbase.sh');
+  });
+
+  function ssh(cmd) {
+    var args = ['-o', 'StrictHostKeyChecking=no',
+                'ec2-user@' + host, cmd];
+    var p = child_process.spawn('ssh', args, {'stdio': 'inherit'});
+    p.on('exit', function(code, signal) {
+      if (cb) cb(code || signal);
+    });
+  }
+}
+
+module.exports = uploadScript;
+
+if (require.main === module)
+  uploadScript(process.argv[2]);
+

--- a/scripts/aws/install_couchbase.sh
+++ b/scripts/aws/install_couchbase.sh
@@ -1,0 +1,20 @@
+
+sudo wget -O/etc/yum.repos.d/couchbase.repo http://packages.couchbase.com/rpm/couchbase-centos62-x86_64.repo
+
+sudo yum check-update && sudo yum install -y libcouchbase-devel
+
+wget http://packages.couchbase.com/releases/2.0.0/couchbase-server-enterprise_x86_64_2.0.0.rpm
+
+sudo yum install -y couchbase-server-enterprise_x86_64_2.0.0.rpm
+
+sleep 15
+
+PASS=`openssl rand -base64 16`
+BUCKET=picl
+
+/opt/couchbase/bin/couchbase-cli cluster-init -c 127.0.0.1:8091 --cluster-init-username=Administrator --cluster-init-password=$PASS --cluster-init-port=8091 --cluster-init-ramsize=1024
+
+/opt/couchbase/bin/couchbase-cli bucket-create -c 127.0.0.1:8091   --bucket=$BUCKET   --bucket-type=couchbase   --bucket-ramsize=1024   --bucket-replica=0   -u Administrator -p $PASS
+
+echo {\"kvstore\": {\"password\":\"${PASS}\", \"bucket\":\"${BUCKET}\"}} > kvstore.json
+sudo mv kvstore.json /home/app/kvstore.json

--- a/scripts/aws/install_couchbase.sh
+++ b/scripts/aws/install_couchbase.sh
@@ -16,5 +16,5 @@ BUCKET=picl
 
 /opt/couchbase/bin/couchbase-cli bucket-create -c 127.0.0.1:8091   --bucket=$BUCKET   --bucket-type=couchbase   --bucket-ramsize=1024   --bucket-replica=0   -u Administrator -p $PASS
 
-echo {\"kvstore\": {\"password\":\"${PASS}\", \"bucket\":\"${BUCKET}\"}} > kvstore.json
+echo {\"couchbase\": {\"password\":\"${PASS}\", \"bucket\":\"${BUCKET}\"}} > kvstore.json
 sudo mv kvstore.json /home/app/kvstore.json

--- a/test/kvstore.js
+++ b/test/kvstore.js
@@ -1,10 +1,11 @@
 var assert = require('assert');
 var kvstore = require('../lib/kvstore');
+var config = require('../lib/config');
 
 describe('kvstore', function () {
 
   it('can set and retrieve keys', function (done) {
-    kvstore.connect(null, function(err, db) {
+    kvstore.connect(config.get('kvstore'), function(err, db) {
       db.set("test-key", "VALUE", function(err) {
         assert.equal(err, null);
         db.get("test-key", function(err, info) {
@@ -17,7 +18,7 @@ describe('kvstore', function () {
   });
 
   it('supports atomic check-and-set', function (done) {
-    kvstore.connect(null, function(err, db) {
+    kvstore.connect(config.get('kvstore'), function(err, db) {
       db.set("test-key", "VALUE", function(err) {
         db.get("test-key", function(err, info) {
           assert.equal(info.value, "VALUE");


### PR DESCRIPTION
This adds a script for installing and configuring couchbase on awsbox machines.

To run tests with couchbase locally, install couchbase and run:

```
DB_BACKEND=couchbase npm test
```
