### PR TITLE
Add synchronous connect() API for kvstore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /loadtest/*.pyc
 /loadtest/report
 /loadtest/loadtest.*
+*.swp

--- a/lib/kvstore.js
+++ b/lib/kvstore.js
@@ -3,24 +3,21 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /**
- * Very lightly abstracted key-value storage for MyFirefox projects.
+ * Very lightly abstracted key-value storage for PiCL projects.
  *
  * This module provides a simple key-value storage API that abstracts away
  * the details of the underlying storage server.  It explicitly mirrors the
  * model used by the memcache protocol.  In production it's currently intended
  * to be couchbase; for local development you can use an in-memory store.
  *
- * To obtain a database connection, call the connect function like this:
+ * To obtain a database connection, call the connect() function:
  *
- *    kvstore = require("lib/kvstore")
- *    kvstore.connect({<options>}, function(err, db) {
- *        ...do stuff with the db...
- *    }
+ *    var kvstore = require('lib/kvstore');
+ *    var db = kvstore.connect({<options>});
  *
- * Default options for the connection will be filled in at runtime, either
- * from the environment or configuration file.
- *
- * The resulting db object has the following methods:
+ * This function takes an options hash to specify details of the underlying
+ * storage backend, and will fill in default options from runtime configuration
+ * data.  It returns a connection object with the following methods:
  *
  *    get(key, cb(<err>, <res>)):   Get the data stored for the given key.
  *                                  The result will be an object with field
@@ -53,10 +50,20 @@
  *      });
  *  });
  *
+ * Each of the connection methods will transparently block until the underlying
+ * storage backend connection is established, which allows calls to connect()
+ * to be made synchronously.  If you need to be notified when the underlying
+ * connection has been established, pass a callback to connect() like so:
+ *
+ *    kvstore.connect({<options>}, function(err, db) {
+ *        ...do stuff with the db...
+ *    }
+ *
  */
 
 var config = require('./config');
 var Hapi = require('hapi');
+
 
 // The set of default options to use for new db connections in this process.
 var DEFAULT_OPTIONS = config.get('kvstore');
@@ -76,8 +83,8 @@ module.exports = {
   connect: function(options, cb) {
     options = Hapi.utils.applyToDefaults(DEFAULT_OPTIONS, options);
 
-    // Load the specified backend implementation, and just pass things on
-    // to its own connect() method.
+    // Load the specified backend implementation
+    // if it's not already available.
     var backend = AVAILABLE_BACKENDS[options.backend];
     if(backend === undefined) {
         cb("invalid kvstore backend: " + backend);
@@ -87,7 +94,93 @@ module.exports = {
         backend = require("./kvstore/" + options.backend + ".js");
         AVAILABLE_BACKENDS[options.backend] = backend;
     }
-    backend.connect(options, cb);
-  }
 
+    // Create a blocking proxy object to return from this function.
+    // It will act just like the underlying backend connection, but
+    // all method calls will block until the connection is established.
+    var proxy = makeBlockingProxy();
+
+    // Connect via the backend implementation, and have it unblock
+    // the proxy object upon completion.
+    backend.connect(options, function(err, db) {
+      proxy._unblock(err, db);
+      if (cb) cb(err, db);
+    });
+
+    return proxy;
+  }
+}
+
+
+// Function to create a blocking proxy for a yet-to-be-established connection.
+// This returns an object that looks and acts just like a kvstore connection,
+// but whose method calls all transparently block until a real connection (or
+// connection error) is provided asynchronously.
+//
+function makeBlockingProxy() {
+  // The proxy object to return.
+  var proxy = {};
+
+  // Variables to hold the connection, or connection error, once established.
+  var dbConnection = null;
+  var dbError = null;
+
+  // List of calls that are blocked waiting for the connection to be provided.
+  var waitList = []
+
+  // Create a transparently-blocking method that proxies to the named method
+  // on the underlying connection.
+  //
+  function makeBlockingMethod(methodName) {
+    return function() {
+      if (dbConnection !== null) {
+        // The connection is ready, immediately call the underlying method.
+        dbConnection[methodName].apply(dbConnection, arguments);
+      } else if (dbError !== null) {
+        // The connection errored out, call the callback with an error.
+        // All kvstore methods take a callback as their final argument.
+        arguments[arguments.length - 1].call(undefined, dbError);
+      } else {
+        // The connection is pending, add this call to the waitlist.
+        console.log("BLOCKING CALL", methodName);
+        waitList.push({ methodName: methodName, arguments: arguments });
+        console.log(waitList);
+      }
+    };
+  }
+  proxy.get = makeBlockingMethod("get");
+  proxy.set = makeBlockingMethod("set");
+  proxy.cas = makeBlockingMethod("cas");
+  proxy.delete = makeBlockingMethod("delete");
+
+  // Private method which is called to provide the connection once established.
+  // This will continue execution of any waiting calls.
+  //
+  proxy._unblock = function _unblock(err, db) {
+    // Record the connection or error into the closed-over variables.
+    // If the connection was successful, optimize future use of the proxy
+    // proxy by copying over methods from the underlying connection.
+    if (err) {
+      dbError = err;
+    } else {
+      dbConnection = db;
+      proxy.get = db.get.bind(db);
+      proxy.set = db.set.bind(db);
+      proxy.cas = db.cas.bind(db);
+      proxy.delete = db.delete.bind(db);
+    }
+    // Resume any calls that are waiting for the connection.
+    // By re-calling the named method on the proxy object, we avoid duplicating
+    // the connection-or-error fulfillment logic from makeBlockingMethod().
+    waitList.forEach(function(blockedCall) {
+      process.nextTick(function() {
+        proxy[blockedCall.methodName].apply(proxy, blockedCall.arguments);
+      });
+    });
+    // Clean up so that things can be GC'd.
+    waitList = null;
+    delete proxy._unblock;
+  }
+ 
+  return proxy;
 }

--- a/lib/kvstore.js
+++ b/lib/kvstore.js
@@ -74,7 +74,7 @@ var AVAILABLE_BACKENDS = DEFAULT_OPTIONS.available_backends.reduce(
 module.exports = {
 
   connect: function(options, cb) {
-    options = Hapi.utils.merge(options, DEFAULT_OPTIONS);
+    options = Hapi.utils.applyToDefaults(DEFAULT_OPTIONS, options);
 
     // Load the specified backend implementation, and just pass things on
     // to its own connect() method.

--- a/test/kvstore.js
+++ b/test/kvstore.js
@@ -5,32 +5,30 @@ var config = require('../lib/config');
 describe('kvstore', function () {
 
   it('can set and retrieve keys', function (done) {
-    kvstore.connect(config.get('kvstore'), function(err, db) {
-      db.set("test-key", "VALUE", function(err) {
+    var db = kvstore.connect(config.get('kvstore'));
+    db.set("test-key", "VALUE", function(err) {
+      assert.equal(err, null);
+      db.get("test-key", function(err, info) {
         assert.equal(err, null);
-        db.get("test-key", function(err, info) {
-          assert.equal(err, null);
-          assert.equal(info.value, "VALUE");
-          done();
-        });
+        assert.equal(info.value, "VALUE");
+        done();
       });
     });
   });
 
   it('supports atomic check-and-set', function (done) {
-    kvstore.connect(config.get('kvstore'), function(err, db) {
-      db.set("test-key", "VALUE", function(err) {
-        db.get("test-key", function(err, info) {
-          assert.equal(info.value, "VALUE");
-          db.cas("test-key", "OTHER-VALUE-ONE", info.casid, function(err) {
-            assert.equal(err, null);
-            db.cas("test-key", "OTHER-VALUE-TWO", info.casid, function(err) {
-              assert.notEqual(err, null);
-              db.get("test-key", function(err, info) {
-                assert.equal(err, null);
-                assert.equal(info.value, "OTHER-VALUE-ONE");
-                done();
-              });
+    var db = kvstore.connect(config.get('kvstore'));
+    db.set("test-key", "VALUE", function(err) {
+      db.get("test-key", function(err, info) {
+        assert.equal(info.value, "VALUE");
+        db.cas("test-key", "OTHER-VALUE-ONE", info.casid, function(err) {
+          assert.equal(err, null);
+          db.cas("test-key", "OTHER-VALUE-TWO", info.casid, function(err) {
+            assert.notEqual(err, null);
+            db.get("test-key", function(err, info) {
+              assert.equal(err, null);
+              assert.equal(info.value, "OTHER-VALUE-ONE");
+              done();
             });
           });
         });


### PR DESCRIPTION
This PR adapts some ideas we've used in picl-tabs and picl-keyserver, to provide a synchronous connection API for kvstore.  It allows you to call kvstore.connect() and just start using the returned object to access the db.  Under the covers, method calls transparently suspend until the connection is established.

@zaach thoughts?
