### PR TITLE
Syncstore auth prereq

### DIFF
--- a/lib/prereqs.js
+++ b/lib/prereqs.js
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Prerequesites can be included in a route's configuration and will run
+// before the route's handler is called. Results are set on
+// the request.pre object using the method's name for the property name,
+// or otherwise using the value of the "assign" property.
+
+const Hapi = require('hapi');
+
+module.exports = {
+
+  checkUserId: function checkUserId(request, next) {
+    var userid = request.params.userid;
+    if (userid !== request.session.user) {
+      return next(Hapi.Error.unauthorized('WrongUserid'));
+    }
+    next();
+  }
+
+};

--- a/routes/syncstore.js
+++ b/routes/syncstore.js
@@ -118,7 +118,7 @@ function getCollections(request) {
 
 // Handler function for getting the items in a collection.
 //
-// This fetches the while list of items from the syncstore backend, filters
+// This fetches the whole list of items from the syncstore backend, filters
 // then based on the "ids" and/or "newer" query parameters, and returns the
 // filtered list to the client.
 //

--- a/routes/syncstore.js
+++ b/routes/syncstore.js
@@ -16,6 +16,7 @@
 const Hapi = require('hapi');
 const config = require('../lib/config.js');
 const syncstore = require('../lib/syncstore.js');
+const prereqs = require('../lib/prereqs.js');
 
 const store = syncstore.connect();
 
@@ -31,6 +32,7 @@ exports.routes = [
     handler: getCollections,
     config: {
       description: 'Get information about all collections',
+      pre: [prereqs.checkUserId],
       // XXX TODO: figure out how to exclude 304 responses from this check,
       //           then re-enable the validation.
       //response: {
@@ -47,6 +49,7 @@ exports.routes = [
     handler: getItems,
     config: {
       description: 'Get items from a collection',
+      pre: [prereqs.checkUserId],
       validate: {
         query: {
           ids: Hapi.Types.String(),
@@ -69,6 +72,7 @@ exports.routes = [
     handler: setItems,
     config: {
       description: 'Store items in a collection',
+      pre: [prereqs.checkUserId],
       payload: 'parse',
       response: {
         schema: {
@@ -94,10 +98,6 @@ function getCollections(request) {
   var if_ver = request.raw.req.headers['x-if-modified-since-version'];
   if (if_ver) {
     if_ver = parseInt(if_ver, 10);
-  }
-
-  if (userid !== request.session.user) {
-    return request.reply(Hapi.Error.unauthorized('WrongUserid'));
   }
 
   store.getCollections(userid, function(err, info) {
@@ -127,10 +127,6 @@ function getCollections(request) {
 function getItems(request) {
   var userid = request.params.userid;
   var collection = request.params.collection;
-
-  if (userid !== request.session.user) {
-    return request.reply(Hapi.Error.unauthorized('WrongUserid'));
-  }
 
   var if_ver = request.raw.req.headers['x-if-modified-since-version'];
   if (if_ver) {
@@ -203,10 +199,6 @@ function setItems(request) {
   var if_ver = request.raw.req.headers['x-if-unmodified-since-version'];
   if (if_ver) {
     if_ver = parseInt(if_ver, 10);
-  }
-
-  if (userid !== request.session.user) {
-    return request.reply(Hapi.Error.unauthorized('WrongUserid'));
   }
 
   // Convert the incoming list of items into a hash mapping


### PR DESCRIPTION
Move the userid-auth-checking logic into a prereq function, for easy sharing between views.

This is a prereq that doesn't return a value, which seems to be slightly against the grain of what prereqs are for, but is still seemed like a good fit to me.
