### PR TITLE
Use correct name for "500 Server Error" response

### DIFF
--- a/routes/syncstore.js
+++ b/routes/syncstore.js
@@ -101,7 +101,7 @@ function getCollections(request) {
   }
 
   store.getCollections(userid, function(err, info) {
-    if (err) return request.reply(Hapi.Error.serverError(err));
+    if (err) return request.reply(Hapi.Error.internal(err));
     if (typeof if_ver !== 'undefined') {
       if (info.version <= if_ver) {
         // XXX TODO: figure out the proper hapi way to do this
@@ -134,7 +134,7 @@ function getItems(request) {
   }
 
   store.getItems(userid, collection, function(err, res) {
-    if (err) return request.reply(Hapi.Error.serverError(err));
+    if (err) return request.reply(Hapi.Error.internal(err));
     if (res.version === 0) return request.reply(Hapi.Error.notFound());
 
     // If they sent an If-Modified-Since, we can avoid sending the body.
@@ -230,7 +230,7 @@ function setItems(request) {
           numRetries++;
           return process.nextTick(doSetItems);
         }
-        return request.reply(Hapi.Error.serverError(err));
+        return request.reply(Hapi.Error.internal(err));
       }
       request.reply({ version: res.version });
     });

--- a/routes/token-auth.js
+++ b/routes/token-auth.js
@@ -133,7 +133,7 @@ function updateToken(request) {
               } else {
                 // otherwise, create a new account
                 account.create(currentToken, result.email, function(err) {
-                  if (err) return request.reply(Hapi.Error.serverError(err));
+                  if (err) return request.reply(Hapi.Error.internal(err));
                   request.reply({ success: true, email: result.email });
                 });
               }


### PR DESCRIPTION
Not sure where I got "Hapi.Error.serverError" from, except my imagination.  The correct name is "Hapi.Error.internal".
