### PR TITLE
Error out if the client sends a not-yet-used version number in 'newer'.

### DIFF
--- a/routes/syncstore.js
+++ b/routes/syncstore.js
@@ -153,7 +153,7 @@ function getItems(request) {
     // If they sent a 'newer' param that's ahead of the current state
     // of the server, they're likely doing something wrong.  Error out.
     if (request.query.newer && request.query.newer > res.version) {
-      return request.replay(Hapi.Error.badRequest('unseen version number'));
+      return request.reply(Hapi.Error.badRequest('unseen version number'));
     }
 
     // The list of ids to fetch is given as a comma-separated string.

--- a/routes/syncstore.js
+++ b/routes/syncstore.js
@@ -150,6 +150,12 @@ function getItems(request) {
       }
     }
 
+    // If they sent a 'newer' param that's ahead of the current state
+    // of the server, they're likely doing something wrong.  Error out.
+    if (request.query.newer && request.query.newer > res.version) {
+      return request.replay(Hapi.Error.badRequest('unseen version number'));
+    }
+
     // The list of ids to fetch is given as a comma-separated string.
     // Split it into a proper list if present.
     var targetIds = request.query.ids;
@@ -157,7 +163,7 @@ function getItems(request) {
       targetIds = targetIds.split(',');
     }
 
-    // The store APi alwasy returns all the items.
+    // The store API always returns all the items.
     // Filter them according to the query parameters.
     var items = [];
     for (var id in res.items) {

--- a/test/integration/syncstore.js
+++ b/test/integration/syncstore.js
@@ -176,9 +176,10 @@ describe('syncstore web api', function() {
   it('errors if client sends a not-yet-used version number', function(done) {
     makeRequest('GET', '/storage/col1', function(res) {
       assert.equal(res.statusCode, 200);
-      var newer = res.version + 1;
+      var newer = res.result.version + 1;
       makeRequest('GET', '/storage/col1?newer='+newer, function(res) {
         assert.equal(res.statusCode, 400);
+        assert.equal(res.result.message, 'unseen version number');
         done();
       });
     });

--- a/test/integration/syncstore.js
+++ b/test/integration/syncstore.js
@@ -173,5 +173,16 @@ describe('syncstore web api', function() {
     });
   });
 
+  it('errors if client sends a not-yet-used version number', function(done) {
+    makeRequest('GET', '/storage/col1', function(res) {
+      assert.equal(res.statusCode, 200);
+      var newer = res.version + 1;
+      makeRequest('GET', '/storage/col1?newer='+newer, function(res) {
+        assert.equal(res.statusCode, 400);
+        done();
+      });
+    });
+  });
+
 });
 


### PR DESCRIPTION
Per Issue 28.  Not a full solution, but maybe a useful first step.
