### PR TITLE
Run integration tests against a live server

### DIFF
--- a/lib/syncstore.js
+++ b/lib/syncstore.js
@@ -55,6 +55,11 @@
  *         This method can fail if concurrent writes are attempted.  The error
  *         message in this case will be 'syncstore.writeConflict'.
  *
+ *    deleteUserData(userid, cb(<err>)):
+ *
+ *         Delete all data stored for the given user.  This resets them back
+ *         to an empty data store with version number zero.
+ *
  *
  * Data storage is currently implemented in top of the kvstore API, which
  * means we have to be careful with how we manage concurrency.  The data is
@@ -98,6 +103,7 @@
  *
  */
 
+const async = require('async');
 const Hapi = require('hapi');
 const kvstore = require('./kvstore');
 
@@ -244,8 +250,6 @@ module.exports.connect = function connect(options, cb) {
         }
       }
 
-      // 
-
       // Fetch the current collection document.
       // If it doesn't exist, fill in empty data as default.
       kv.get(collectionKey, function(err, colRes) {
@@ -266,10 +270,18 @@ module.exports.connect = function connect(options, cb) {
         var oldItems = collectionDoc.base.items;
         if (collectionDoc.diff.version === collectionVersion) {
           oldItems = applyDiffItems(oldItems, collectionDoc.diff.items);
-        } else {
+        } else if (collectionDoc.base.version === collectionVersion) {
           if (collectionDoc.diff.ts + WRITE_TIMEOUT >= Date.now()) {
             return cb('syncstore.writeConflict');
           }
+        } else {
+          // The data in the collection does not match the version from
+          // the info doc!  Either we're in the middle of doing a delete,
+          // or something has gone horribly wrong...
+          if (collectionVersion > 0)  {
+            return cb('data corruption detected, ruh-roh!');
+          }
+          oldItems = {};
         }
 
         // Normalize the set of new items, merging in any existing ones
@@ -331,6 +343,41 @@ module.exports.connect = function connect(options, cb) {
             // Success!  Return the updated version number to the caller.
             return cb(null, { version: newVersion });
           });
+        });
+      });
+    });
+  };
+
+
+  // Delete the data stored for the given userid.
+  //
+  //
+  syncstore.deleteUserData = function deleteUserData(userid, cb) {
+
+    // Get the current info document, to know the list of collections.
+    var infoKey = 'syncstore/' + userid;
+    kv.get(infoKey, function(err, info) {
+      if (err) return cb(err);
+      if(!info) return cb(null);
+
+      // Delete the info document first.
+      // This will allow any concurrent clients to see the deletion
+      // and avoid using mismatched, undeleted collection data..
+      kv.delete(infoKey, function(err) {
+        if (err) return cb(err);
+
+        // Now delete the stored data for each collection.
+        // Unfortunately there's no atomic "delete if unmodified" so
+        // there's a race condition here if a concurrent writer is trying
+        // to re-create these collections.
+        var collections = Object.keys(info.value.collections);
+        async.each(collections, function(collection, cb) {
+          var collectionKey = 'syncstore/' + userid + '/' + collection;
+          kv.delete(collectionKey, function(err) {
+            return cb(err);
+          });
+        }, function(err) {
+          return cb(err);
         });
       });
     });

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "mocha": "1.8.1",
-    "jshint": "0.9.1"
+    "jshint": "0.9.1",
+    "request": "2.14.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "joi": "0.1.1",
     "awsbox": "0.4.1",
     "convict": "0.1.x",
-    "async": "0.1.22"
+    "async": "0.2.5"
   },
   "optionalDependencies": {
     "couchbase": "0.0.11"

--- a/routes/syncstore.js
+++ b/routes/syncstore.js
@@ -80,6 +80,15 @@ exports.routes = [
         }
       }
     }
+  },
+  {
+    method: 'DELETE',
+    path: '/{userid}',
+    handler: deleteUserData,
+    config: {
+      description: 'Delete all data for the user',
+      pre: [prereqs.checkUserId]
+    }
   }
 ];
 
@@ -226,4 +235,17 @@ function setItems(request) {
     });
   }
   doSetItems();
+}
+
+
+//  Handler function for deleting all of the user's data.
+//
+function deleteUserData(request) {
+  var userid = request.params.userid;
+
+  store.deleteUserData(userid, function(err) {
+    if (err) return request.reply(Hapi.Error.internal(err));
+    var response = new Hapi.Response.Raw(request).code(204);
+    return request.reply(response);
+  });
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,6 +1,15 @@
 const request = require('request');
+const crypto = require('crypto');
 
 exports.server = require('../server');
+
+
+// Generate a unique, randomly-generated ID.
+// Handy for testing auth tokens and the like..
+//
+exports.uniqueID = function() {
+  return crypto.randomBytes(10).toString('hex');
+};
 
 
 // Construct a request-making function bound either to a local Hapi server

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,22 +1,54 @@
-var http = require('http');
+const request = require('request');
 
 exports.server = require('../server');
 
-exports.makeRequest = function (method, path, options, callback) {
+
+// Construct a request-making function bound either to a local Hapi server
+// instance, or a remote server.
+//
+// Individual testcases can call this function to generate a makeRequest()
+// helper that's bound to their specific server of interest.  Said function
+// will also respect the TEST_REMOTE environment variable to redirect requests
+// against a remote server.
+//
+// XXX TODO: there must be a better name for this function...?
+//
+exports.bindMakeRequest = function(server) {
+  if (process.env.TEST_REMOTE) {
+    return exports.makeLiveRequest.bind({base_url: process.env.TEST_REMOTE});
+  } else {
+    return exports.makeInjectRequest.bind(server);
+  }
+};
+
+
+// Make a HTTP request by injecting calls directly into a Hapi server.
+// This bypasses all networking and node layers and just exercises the
+// application code, making it faster and better for debugging.
+//
+exports.makeInjectRequest = function (method, path, options, callback) {
   if (typeof options === 'function') {
     callback = options;
     options = {};
   }
 
   var next = function (res) {
+    // nodejs lowercases response headers, so simulate that behaviour here.
+    var normalizedHeaders = {};
+    for (var key in res.headers) {
+      if (res.headers.hasOwnProperty(key)) {
+        normalizedHeaders[key.toLowerCase()] = res.headers[key];
+      }
+    }
+    res.headers = normalizedHeaders;
     return callback(res);
   };
 
-  // nodejs lowercases headers, so simulate that behaviour here.
+  // nodejs lowercases request headers, so simulate that behaviour here.
   var rawHeaders = options.headers || {};
   var headers = {};
   for (var key in rawHeaders) {
-    if(rawHeaders.hasOwnProperty(key)) {
+    if (rawHeaders.hasOwnProperty(key)) {
       headers[key.toLowerCase()] = rawHeaders[key];
     }
   }
@@ -29,29 +61,54 @@ exports.makeRequest = function (method, path, options, callback) {
   }, next);
 };
 
-exports.getUser = function(audience, cb) {
-  console.log('getting aud', encodeURIComponent(audience));
 
-  var req = http.request({
-    host: 'personatestuser.org',
-    path: '/email_with_assertion/' + encodeURIComponent(audience) + '/prod',
-    method: 'GET'
-  }, function (res) {
-    var result = '';
-    res.on('data', function(chunk) { result += chunk; });
-    res.on('end', function() {
-      var data;
-      try {
-        data = JSON.parse(result);
-      } catch (e) {
-        return cb(e);
-      }
-      cb(null, data);
-    });
+// Make a HTTP request by actually sending it out over the network.
+// This uses the same API as makeInjectRequest above, but sends it to
+// a live server.  This lets you easily re-use unittests to acceptance
+// test a live server.
+//
+exports.makeLiveRequest = function (method, path, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+
+  var body = "";
+  if (options.payload !== undefined) {
+    body = JSON.stringify(options.payload);
+  }
+
+  request({
+    url: this.base_url + path,
+    method: method,
+    headers: options.headers || {},
+    body: body
+  }, function (err, res, body) {
+    if (err) return callback({statusCode: 599, error: err});
+    if (body && res.headers['content-type'] === 'application/json') {
+      res.result = JSON.parse(body);
+    } else {
+      res.result = body;
+    }
+    return callback(res);
   });
-  req.on('error', function(e) {
-    console.error('get user error:', e);
-    cb(e);
+};
+
+
+// Get an email and assert for a new unique test user.
+//
+exports.getUser = function(audience, cb) {
+  var url = 'http://personatestuser.org/email_with_assertion/';
+  url += encodeURIComponent(audience) + '/prod',
+  request.get(url, function(err, res, body) {
+    if (err) {
+      console.log('get user error:', err);
+      return cb(err);
+    }
+    try {
+      return cb(null, JSON.parse(body));
+    } catch (e) {
+      return cb(e);
+    }
   });
-  req.end();
 };

--- a/test/integration/auth.js
+++ b/test/integration/auth.js
@@ -3,7 +3,7 @@ var config = require('../../lib/config');
 var helpers = require('../helpers');
 
 var server = helpers.server;
-var makeRequest = helpers.makeRequest.bind(server);
+var makeRequest = helpers.bindMakeRequest(server);
 
 var TEST_AUDIENCE = config.get('public_url');
 var TEST_EMAIL;

--- a/test/integration/auth.js
+++ b/test/integration/auth.js
@@ -8,8 +8,9 @@ var makeRequest = helpers.bindMakeRequest(server);
 var TEST_AUDIENCE = config.get('public_url');
 var TEST_EMAIL;
 var TEST_ASSERTION;
-var TEST_TOKEN = 'foobar';
-var TEST_NEW_TOKEN = 'shabushabu';
+var TEST_TOKEN = helpers.uniqueID();
+var TEST_NEW_TOKEN = helpers.uniqueID();
+var TEST_NEWER_TOKEN = helpers.uniqueID();
 
 describe('get user', function() {
   it('can get user email and assertion', function(done) {
@@ -79,7 +80,7 @@ describe('auth', function() {
 
   it('creates a new account with a new token', function(done) {
     makeRequest('PUT', '/update_token', {
-      payload: { assertion: TEST_ASSERTION, token: 'new token' }
+      payload: { assertion: TEST_ASSERTION, token: TEST_NEWER_TOKEN }
     }, function(res) {
       assert.equal(res.statusCode, 200);
       assert.deepEqual(res.result, { success: true, email: TEST_EMAIL });

--- a/test/integration/auth.js
+++ b/test/integration/auth.js
@@ -2,8 +2,7 @@ var assert = require('assert');
 var config = require('../../lib/config');
 var helpers = require('../helpers');
 
-var server = helpers.server;
-var makeRequest = helpers.bindMakeRequest(server);
+var testClient = new helpers.TestClient();
 
 var TEST_AUDIENCE = config.get('public_url');
 var TEST_EMAIL;
@@ -29,7 +28,7 @@ describe('get user', function() {
 
 describe('auth', function() {
   it('creates a new account', function(done) {
-    makeRequest('PUT', '/update_token', {
+    testClient.makeRequest('PUT', '/update_token', {
       payload: { assertion: TEST_ASSERTION, token: TEST_TOKEN, oldTokens: [ 'not', 'used' ] }
     }, function(res) {
       assert.equal(res.statusCode, 200);
@@ -39,7 +38,7 @@ describe('auth', function() {
   });
 
   it('fails to update new token when old token is invalid', function(done) {
-    makeRequest('PUT', '/update_token', {
+    testClient.makeRequest('PUT', '/update_token', {
       payload: { assertion: TEST_ASSERTION, token: TEST_NEW_TOKEN, oldTokens: [ 'bad' ] }
     }, function(res) {
       assert.equal(res.statusCode, 401);
@@ -49,7 +48,7 @@ describe('auth', function() {
   });
 
   it('updates new token when an old token is valid', function(done) {
-    makeRequest('PUT', '/update_token', {
+    testClient.makeRequest('PUT', '/update_token', {
       payload: { assertion: TEST_ASSERTION, token: TEST_NEW_TOKEN, oldTokens: [ 'bad', TEST_TOKEN ] }
     }, function(res) {
       assert.equal(res.statusCode, 200);
@@ -59,7 +58,7 @@ describe('auth', function() {
   });
 
   it('succeeds using the current token', function(done) {
-    makeRequest('PUT', '/update_token', {
+    testClient.makeRequest('PUT', '/update_token', {
       payload: { assertion: TEST_ASSERTION, token: TEST_NEW_TOKEN }
     }, function(res) {
       assert.equal(res.statusCode, 200);
@@ -69,7 +68,7 @@ describe('auth', function() {
   });
 
   it('deletes the account', function(done) {
-    makeRequest('DELETE', '/account', {
+    testClient.makeRequest('DELETE', '/account', {
       payload: { assertion: TEST_ASSERTION }
     }, function(res) {
       assert.equal(res.statusCode, 200);
@@ -79,7 +78,7 @@ describe('auth', function() {
   });
 
   it('creates a new account with a new token', function(done) {
-    makeRequest('PUT', '/update_token', {
+    testClient.makeRequest('PUT', '/update_token', {
       payload: { assertion: TEST_ASSERTION, token: TEST_NEWER_TOKEN }
     }, function(res) {
       assert.equal(res.statusCode, 200);

--- a/test/integration/blob.js
+++ b/test/integration/blob.js
@@ -1,15 +1,14 @@
 var assert = require('assert');
 var helpers = require('../helpers');
 
-var server = helpers.server;
-var makeRequest = helpers.bindMakeRequest(server);
+var testClient = new helpers.TestClient();
 
 var TEST_EMAIL = helpers.uniqueID() + '@example.com';
 var TEST_TOKEN = helpers.uniqueID();
 
 describe('set up account', function() {
   it('creates a new account', function(done) {
-    makeRequest('PUT', '/update_token', {
+    testClient.makeRequest('PUT', '/update_token', {
       payload: { email: TEST_EMAIL, token: TEST_TOKEN, oldTokens: [ 'not', 'used' ] }
     }, function(res) {
       assert.equal(res.statusCode, 200);
@@ -21,7 +20,7 @@ describe('set up account', function() {
 
 describe('blob', function() {
   it('should store a blob', function(done) {
-    makeRequest('PUT', '/blob', {
+    testClient.makeRequest('PUT', '/blob', {
       payload: { data: 'my awesome data', casid: 1 },
       headers: { Authorization: TEST_TOKEN }
     }, function(res) {
@@ -32,7 +31,7 @@ describe('blob', function() {
   });
 
   it('should get a blob', function(done) {
-    makeRequest('GET', '/blob', {
+    testClient.makeRequest('GET', '/blob', {
       headers: { Authorization: TEST_TOKEN }
     }, function(res) {
       assert.equal(res.statusCode, 200);
@@ -46,7 +45,7 @@ describe('blob', function() {
   // XXX TODO: re-enable this as security model grows.
   //
   //it('should fail on bad Authorization header', function(done) {
-  //  makeRequest('GET', '/blob', {
+  //  testClient.makeRequest('GET', '/blob', {
   //    headers: { Authorization: 'bad' }
   //  }, function(res) {
   //    assert.equal(res.statusCode, 401);

--- a/test/integration/blob.js
+++ b/test/integration/blob.js
@@ -2,7 +2,7 @@ var assert = require('assert');
 var helpers = require('../helpers');
 
 var server = helpers.server;
-var makeRequest = helpers.makeRequest.bind(server);
+var makeRequest = helpers.bindMakeRequest(server);
 
 var TEST_EMAIL = 'blob@example.com';
 var TEST_TOKEN = 'blobtoken';

--- a/test/integration/blob.js
+++ b/test/integration/blob.js
@@ -4,8 +4,8 @@ var helpers = require('../helpers');
 var server = helpers.server;
 var makeRequest = helpers.bindMakeRequest(server);
 
-var TEST_EMAIL = 'blob@example.com';
-var TEST_TOKEN = 'blobtoken';
+var TEST_EMAIL = helpers.uniqueID() + '@example.com';
+var TEST_TOKEN = helpers.uniqueID();
 
 describe('set up account', function() {
   it('creates a new account', function(done) {

--- a/test/integration/fakeAuth.js
+++ b/test/integration/fakeAuth.js
@@ -2,7 +2,7 @@ var assert = require('assert');
 var helpers = require('../helpers');
 
 var server = helpers.server;
-var makeRequest = helpers.makeRequest.bind(server);
+var makeRequest = helpers.bindMakeRequest(server);
 
 var TEST_EMAIL = 'foo@example.com';
 var TEST_TOKEN = 'fake';

--- a/test/integration/fakeAuth.js
+++ b/test/integration/fakeAuth.js
@@ -1,8 +1,7 @@
 var assert = require('assert');
 var helpers = require('../helpers');
 
-var server = helpers.server;
-var makeRequest = helpers.bindMakeRequest(server);
+var testClient = new helpers.TestClient();
 
 var TEST_EMAIL = helpers.uniqueID() + '@example.com';
 var TEST_TOKEN = helpers.uniqueID();
@@ -11,7 +10,7 @@ var TEST_NEWER_TOKEN = helpers.uniqueID();
 
 describe('fake auth', function() {
   it('creates a new account', function(done) {
-    makeRequest('PUT', '/update_token', {
+    testClient.makeRequest('PUT', '/update_token', {
       payload: { email: TEST_EMAIL, token: TEST_TOKEN, oldTokens: [ 'not', 'used' ] }
     }, function(res) {
       assert.equal(res.statusCode, 200);
@@ -21,7 +20,7 @@ describe('fake auth', function() {
   });
 
   it('fails to update new token when old token is invalid', function(done) {
-    makeRequest('PUT', '/update_token', {
+    testClient.makeRequest('PUT', '/update_token', {
       payload: { email: TEST_EMAIL, token: TEST_NEW_TOKEN, oldTokens: [ 'bad' ] }
     }, function(res) {
       assert.equal(res.statusCode, 401);
@@ -31,7 +30,7 @@ describe('fake auth', function() {
   });
 
   it('updates new token when an old token is valid', function(done) {
-    makeRequest('PUT', '/update_token', {
+    testClient.makeRequest('PUT', '/update_token', {
       payload: { email: TEST_EMAIL, token: TEST_NEW_TOKEN, oldTokens: [ 'bad', TEST_TOKEN ] }
     }, function(res) {
       assert.equal(res.statusCode, 200);
@@ -41,7 +40,7 @@ describe('fake auth', function() {
   });
 
   it('succeeds using the current token', function(done) {
-    makeRequest('PUT', '/update_token', {
+    testClient.makeRequest('PUT', '/update_token', {
       payload: { email: TEST_EMAIL, token: TEST_NEW_TOKEN }
     }, function(res) {
       assert.equal(res.statusCode, 200);
@@ -51,7 +50,7 @@ describe('fake auth', function() {
   });
 
   it('deletes the account', function(done) {
-    makeRequest('DELETE', '/account', {
+    testClient.makeRequest('DELETE', '/account', {
       payload: { email: TEST_EMAIL }
     }, function(res) {
       assert.equal(res.statusCode, 200);
@@ -61,7 +60,7 @@ describe('fake auth', function() {
   });
 
   it('creates a new account with a new token', function(done) {
-    makeRequest('PUT', '/update_token', {
+    testClient.makeRequest('PUT', '/update_token', {
       payload: { email: TEST_EMAIL, token: TEST_NEWER_TOKEN }
     }, function(res) {
       assert.equal(res.statusCode, 200);

--- a/test/integration/fakeAuth.js
+++ b/test/integration/fakeAuth.js
@@ -4,9 +4,10 @@ var helpers = require('../helpers');
 var server = helpers.server;
 var makeRequest = helpers.bindMakeRequest(server);
 
-var TEST_EMAIL = 'foo@example.com';
-var TEST_TOKEN = 'fake';
-var TEST_NEW_TOKEN = 'fakenew';
+var TEST_EMAIL = helpers.uniqueID() + '@example.com';
+var TEST_TOKEN = helpers.uniqueID();
+var TEST_NEW_TOKEN = helpers.uniqueID();
+var TEST_NEWER_TOKEN = helpers.uniqueID();
 
 describe('fake auth', function() {
   it('creates a new account', function(done) {
@@ -61,7 +62,7 @@ describe('fake auth', function() {
 
   it('creates a new account with a new token', function(done) {
     makeRequest('PUT', '/update_token', {
-      payload: { email: TEST_EMAIL, token: 'fake new token' }
+      payload: { email: TEST_EMAIL, token: TEST_NEWER_TOKEN }
     }, function(res) {
       assert.equal(res.statusCode, 200);
       assert.deepEqual(res.result, { success: true, email: TEST_EMAIL });

--- a/test/integration/heartbeat.js
+++ b/test/integration/heartbeat.js
@@ -1,11 +1,11 @@
 var assert = require('assert');
 var helpers = require('../helpers');
-var server = helpers.server;
-var makeRequest = helpers.bindMakeRequest(server);
+
+var testClient = new helpers.TestClient();
 
 describe('heartbeat', function() {
   it('returns ok', function(done) {
-    makeRequest('GET', '/__heartbeat__', function(res) {
+    testClient.makeRequest('GET', '/__heartbeat__', function(res) {
       assert.equal(res.statusCode, 200);
       assert.equal(res.result, 'ok');
       done();

--- a/test/integration/heartbeat.js
+++ b/test/integration/heartbeat.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var helpers = require('../helpers');
 var server = helpers.server;
-var makeRequest = helpers.makeRequest.bind(server);
+var makeRequest = helpers.bindMakeRequest(server);
 
 describe('heartbeat', function() {
   it('returns ok', function(done) {

--- a/test/integration/hello.js
+++ b/test/integration/hello.js
@@ -1,11 +1,10 @@
 var assert = require('assert');
 var helpers = require('../helpers');
-var server = helpers.server;
-var makeRequest = helpers.bindMakeRequest(server);
+var testClient = new helpers.TestClient();
 
 describe('hello', function () {
   it('returns custom error response', function (done) {
-    makeRequest('GET', '/hello', function (res) {
+    testClient.makeRequest('GET', '/hello', function (res) {
       assert.equal(res.statusCode, 200);
       assert.deepEqual(res.result, { greeting: 'it works' });
       done();

--- a/test/integration/hello.js
+++ b/test/integration/hello.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var helpers = require('../helpers');
 var server = helpers.server;
-var makeRequest = helpers.makeRequest.bind(server);
+var makeRequest = helpers.bindMakeRequest(server);
 
 describe('hello', function () {
   it('returns custom error response', function (done) {

--- a/test/integration/syncstore.js
+++ b/test/integration/syncstore.js
@@ -7,6 +7,8 @@ const TEST_TOKEN = 'faketoken';
 
 describe('syncstore web api', function() {
 
+  var origMakeRequest = helpers.bindMakeRequest(server);
+
   // Request helper that automatically prepands endpoint to the url
   // and adds authorization headers.
   function makeRequest(method, url, options, cb) {
@@ -21,7 +23,7 @@ describe('syncstore web api', function() {
     if (!options.headers.Authorization) {
       options.headers.Authorization = TEST_TOKEN;
     }
-    return helpers.makeRequest.call(server, method, url, options, cb);
+    return origMakeRequest(method, url, options, cb);
   }
 
   // Map a list of BSOs into an object keyed by item id.
@@ -124,7 +126,7 @@ describe('syncstore web api', function() {
   it('sends a last-modified header with GET responses', function(done) {
     makeRequest('GET', '/storage/col1', function(res) {
       assert.equal(res.statusCode, 200);
-      assert.equal(res.result.version, res.headers['X-Last-Modified-Version']);
+      assert.equal(res.result.version, res.headers['x-last-modified-version']);
       done();
     });
   });

--- a/test/integration/syncstore.js
+++ b/test/integration/syncstore.js
@@ -193,5 +193,15 @@ describe('syncstore web api', function() {
     });
   });
 
-});
+  it('lets me delete all of my data', function(done) {
+    makeRequest('DELETE', '', function(res) {
+      assert.equal(res.statusCode, 204);
+      makeRequest('GET', '/info/collections', function(res) {
+        assert.equal(res.statusCode, 200);
+        assert.equal(res.result.version, 0);
+        done();
+      });
+    });
+  });
 
+});


### PR DESCRIPTION
(not yet ready for merge)

This is an experiment in re-using the integration tests for acceptance testing of a live server instance.  As before, doing the usual `npm test` will run tests against an in-memory Hapi server using inject().  But if you specify TEST_REMOTE environment variable, then the tests will be redirected at a live server.  If you've got it running locally:

```
$ TEST_REMOTE=http://localhost:8080 npm test
```

I'm not thrilled about the naming of functions makeLiveRequest/makeInjectRequest/bindMakeRequest, any suggestions would be appreciated.  But the overall approach seems to work well.

For this to be truly useful, we need to make the tests do proper cleanup so that they can be run multiple times against a single server.  I've made a start on this for the syncstore routes, but auth and blob tests also need to be tweaked.

@zaach @ckarlof thoughts?
