### PR TITLE
Use a fresh connection for each request to couchbase

### DIFF
--- a/lib/kvstore/couchbase.js
+++ b/lib/kvstore/couchbase.js
@@ -16,6 +16,8 @@ module.exports = {
 
   connect: function(options, cb) {
     options = Hapi.utils.merge(options, config.get('couchbase'));
+    // Enable debugging by default, since we're still in development mode.
+    if (options.debug !== false) options.debug = true;
 
     couchbase.connect(options, function(err, bucket) {
       if (err) return cb(err);

--- a/lib/kvstore/couchbase.js
+++ b/lib/kvstore/couchbase.js
@@ -19,13 +19,12 @@ module.exports = {
     // Enable debugging by default, since we're still in development mode.
     if (options.debug !== false) options.debug = true;
 
-    couchbase.connect(options, function(err, bucket) {
-      if (err) return cb(err);
+    // Following the lead of couchbase node module, this is using closures
+    // and simple objects rather than instantiating a prototype connection.
 
-      // Following the lead of couchbase node module, this is using closures
-      // and simple objects rather than instantiating a prototype connection.
-
-      function get(key, cb) {
+    function get(key, cb) {
+      couchbase.connect(options, function(err, bucket) {
+        if (err) return cb(err);
         bucket.get(key, function(err, value, meta) {
           if (err) {
             if (err.code === couchbase.errors.keyNotFound) {
@@ -35,15 +34,21 @@ module.exports = {
           }
           return cb(null, { value: value, casid: meta.cas });
         });
-      }
+      });
+    }
 
-      function set(key, value, cb) {
+    function set(key, value, cb) {
+      couchbase.connect(options, function(err, bucket) {
+        if (err) return cb(err);
         bucket.set(key, value, function(err) {
           cb(err);
         });
-      }
+      });
+    }
 
-      function cas(key, value, casid, cb) {
+    function cas(key, value, casid, cb) {
+      couchbase.connect(options, function(err, bucket) {
+        if (err) return cb(err);
         // Couchbase has different methods for "set if not exists" and
         // "set if not modified".  This function is the common callback
         // logic to be aplied after either.
@@ -58,9 +63,12 @@ module.exports = {
         } else {
           bucket.set(key, value, {cas: casid}, handler);
         }
-      }
+      });
+    }
 
-      function del(key, cb) {
+    function del(key, cb) {
+      couchbase.connect(options, function(err, bucket) {
+        if (err) return cb(err);
         bucket.remove(key, function(err) {
           if (err) {
             if (err.code === couchbase.errors.keyNotFound) {
@@ -69,10 +77,10 @@ module.exports = {
           }
           cb(err);
         });
-      }
+      });
+    }
 
-      cb(null, {get: get, set: set, cas: cas, delete: del});
-    });
+    cb(null, {get: get, set: set, cas: cas, delete: del});
   }
 
 };


### PR DESCRIPTION
This uses a fresh connection to couchbase for each individual couchbase method call.  It's not the sort of thing you want to do in production, but might help show whether couchbase is behind the strange server lockups we've been seeing.
