### PR TITLE
Better loadtesting, plus integrate with marteau

### DIFF
--- a/.awsboxen/Profiles/MockProduction/Resources.json
+++ b/.awsboxen/Profiles/MockProduction/Resources.json
@@ -1,0 +1,6 @@
+{
+  "WebServer": null,
+  "DNSRecord": { "Properties": {
+    "ResourceRecords":  [{"Fn::GetAtt": ["LoadBalancer", "DNSName"]}]
+  }}
+}

--- a/.awsboxen/Resources.json
+++ b/.awsboxen/Resources.json
@@ -1,0 +1,37 @@
+{
+  "DNSRecord": {
+    "Type": "AWS::Route53::RecordSet",
+    "Properties": {
+      "Comment": "Latest awsboxen deployment of picl-server",
+      "HostedZoneName": "profileinthecloud.net.",
+      "Name": "loadtest.storage.profileinthecloud.net.",
+      "Type": "CNAME",
+      "TTL": "30",
+      "ResourceRecords": [{"Fn::GetAtt": ["WebServer", "PublicDnsName"]}]
+    }
+  },
+
+  "WebServer": {
+    "Type" : "AWS::EC2::Instance",
+    "Properties" : {
+      "InstanceType" : "m1.small",
+      "ImageId": { "Ref": "AWSBoxAMI" },
+      "KeyName": { "Ref": "AWSBoxDeployKey" },
+      "SecurityGroups": [ {"Ref": "WebServerSecurityGroup"} ]
+    }
+  },
+
+  "WebServerSecurityGroup": {
+    "Type" : "AWS::EC2::SecurityGroup",
+    "Properties" : {
+      "GroupDescription" : "Enable HTTP and SSH access",
+      "SecurityGroupIngress" : [
+        {"IpProtocol" : "tcp",
+         "FromPort" : "80", "ToPort" : "80", "CidrIp" : "0.0.0.0/0"},
+        {"IpProtocol" : "tcp",
+         "FromPort" : "22", "ToPort" : "22", "CidrIp" : "0.0.0.0/0"}
+      ]
+    }
+  }
+
+}

--- a/.marteau.yml
+++ b/.marteau.yml
@@ -1,7 +1,7 @@
 name: PICL-Server
 wdir: loadtest
 script: stress.py
-test: StressTest.test_hello_world
+test: StressTest.test_syncstore_read_and_write
 nodes: 4
 email: rfkelly@mozilla.com
 cycles: '10:20:30:50'

--- a/loadtest/Makefile
+++ b/loadtest/Makefile
@@ -11,4 +11,4 @@ test:
 
 # run actual funkload bench (called from dist.sh over ssh)
 bench:
-	bin/fl-run-bench stress.py StressTest.test_hello_world
+	bin/fl-run-bench stress.py StressTest.test_syncstore_read_and_write

--- a/loadtest/StressTest.conf
+++ b/loadtest/StressTest.conf
@@ -1,7 +1,7 @@
 [main]
 title=PICL Server Funkload test
 description=Simple PICL Server Test
-url=http://picl-mock-loadbala-1brd7qruss7fh-2096001400.us-east-1.elb.amazonaws.com/
+url=http://loadtest.storage.profileinthecloud.net/
 
 [ftest]
 log_to = console file

--- a/loadtest/stress.py
+++ b/loadtest/stress.py
@@ -6,16 +6,50 @@ Load test for the PICL server
 """
 
 import json
+import uuid
+import random
 
 from funkload.FunkLoadTestCase import FunkLoadTestCase
+from funkload.utils import Data
+
 
 class StressTest(FunkLoadTestCase):
 
     def setUp(self):
         self.server_url = self.conf_get("main", "url")
+        if not self.server_url.endswith("/"):
+            self.server_url += "/"
 
     def test_hello_world(self):
         self.setOkCodes([200])
         response = self.get(self.server_url + "/hello")
         self.assertTrue(response.body != '')
         self.assertEquals(json.loads(response.body)["greeting"], "it works")
+
+    def test_syncstore_read_and_write(self):
+        COLLECTIONS = ["history", "bookmarks", "tabs", "passwords"]
+        auth_token = uuid.uuid4().hex
+        base_url = self.server_url + auth_token
+        # Start by getting the info document.
+        self.setHeader("Authorization", auth_token)
+        self.setOkCodes([200])
+        self.get(base_url + "/info/collections")
+        # Read the items from a random collections.
+        coll = random.choice(COLLECTIONS)
+        self.setOkCodes([200, 404])
+        self.get(base_url + "/storage/" + coll)
+        # Write some new items into a random collection.
+        coll = random.choice(COLLECTIONS)
+        items = {}
+        while len(items) < 10:
+            id = "item%s" % (random.randrange(0, 100),)
+            items[id] = { "id": id, "payload": "DATADATADATA" }
+        data = Data("application/json", json.dumps(items.values()))
+        self.setOkCodes([200])
+        r = self.post(base_url + "/storage/" + coll, params=data)
+        last_modified = int(r.headers["x-last-modified-version"])
+        # Check the collection info again and sanity-check the version nums.
+        r = self.get(base_url + "/info/collections")
+        info = json.loads(r.body)
+        assert last_modified <= info["collections"][coll]
+ 


### PR DESCRIPTION
This changes the awsboxen config so that "http://loadtest.storage.profileinthecloud.net" will point to the most recent deployment.  It also changes the loadtest to actually exercise the syncstore API, and points marteau at it.

With this merged, submitting loadtests via marteau should actually do something marginally useful.

@zaach r?
