### PR TITLE
Store push server endpoints and ping them on version updates

### DIFF
--- a/lib/syncstore.js
+++ b/lib/syncstore.js
@@ -404,9 +404,8 @@ module.exports.connect = function connect(options, cb) {
 
       endpoints[endpoint] = +new Date();
       var casid = eps ? eps.casid : null;
-      kv.cas(infoKey, endpoints, casid,  function(err) {
-        cb(err);
-      });
+      var fn = kv.cas.bind(kv, infoKey, endpoints, casid);
+      retryLoop(fn, 10, cb);
     });
   };
 
@@ -419,9 +418,8 @@ module.exports.connect = function connect(options, cb) {
       if (endpoints && endpoints.value[endpoint]) {
         delete endpoints.value[endpoint];
         var casid = endpoints ? endpoints.casid : null;
-        kv.cas(infoKey, endpoints.value, casid, function(err) {
-          cb(err);
-        });
+        var fn = kv.cas.bind(kv, infoKey, endpoints.value, casid);
+        retryLoop(fn, 10, cb);
       } else {
         cb('syncstore.unknownEndpoint');
       }
@@ -468,6 +466,26 @@ module.exports.connect = function connect(options, cb) {
     if (!item.deleted) item.deleted = false;
     return item;
   }
+
+  // fn should be the function to execute, with its arguments bound except for the callback
+  function retryLoop(fn, maxAttempts, cb) {
+    var numRetries = 0;
+    var attempt = function() {
+      fn(function(err) {
+        if (err) {
+          if (err !== 'cas mismatch') return cb(err);
+          if (numRetries > maxAttempts) return cb('too many conflicts');
+          numRetries++;
+          process.nextTick(attempt);
+        } else {
+          // success! exit retry loop
+          cb(null);
+        }
+      });
+    };
+    attempt();
+  }
+
 
   return syncstore;
 };

--- a/lib/syncstore.js
+++ b/lib/syncstore.js
@@ -403,7 +403,8 @@ module.exports.connect = function connect(options, cb) {
       if (eps) endpoints = eps.value;
 
       endpoints[endpoint] = +new Date();
-      kv.set(infoKey, endpoints, function(err) {
+      var casid = eps ? eps.casid : null;
+      kv.cas(infoKey, endpoints, casid,  function(err) {
         cb(err);
       });
     });
@@ -415,9 +416,10 @@ module.exports.connect = function connect(options, cb) {
     kv.get(infoKey, function(err, endpoints) {
       if (err) return cb(err);
 
-      if (endpoints.value[endpoint]) {
+      if (endpoints && endpoints.value[endpoint]) {
         delete endpoints.value[endpoint];
-        kv.set(infoKey, endpoints.value, function(err) {
+        var casid = endpoints ? endpoints.casid : null;
+        kv.cas(infoKey, endpoints.value, casid, function(err) {
           cb(err);
         });
       } else {

--- a/lib/syncstore.js
+++ b/lib/syncstore.js
@@ -383,15 +383,54 @@ module.exports.connect = function connect(options, cb) {
     });
   };
 
+  // Add a pushserver endpoint
+  syncstore.addEndpoint = function(userid, endpoint, cb) {
+    var infoKey = 'endpoints/' + userid;
+    kv.get(infoKey, function(err, endpoints) {
+      if (err) return cb(err);
+      if (!endpoints) endpoints = {};
+      if (!endpoints[endpoint]) {
+        endpoints[endpoint] = +new Date();
+        kv.set(infoKey, endpoints, function(err) {
+          cb(err);
+        });
+      }
+    });
+  };
+
+  // Add a pushserver endpoint
+  syncstore.deleteEndpoint = function(userid, endpoint, cb) {
+    var infoKey = 'endpoints/' + userid;
+    kv.get(infoKey, function(err, endpoints) {
+      if (err) return cb(err);
+
+      if (endpoints.value[endpoint]) {
+        delete endpoints.value[endpoint];
+        kv.set(infoKey, endpoints.value, function(err) {
+          cb(err);
+        });
+      } else {
+        cb('syncstore.unknownEndpoint');
+      }
+    });
+  };
+
+  syncstore.getEndpoints = function(userid, cb) {
+    var infoKey = 'endpoints/' + userid;
+    kv.get(infoKey, function(err, endpoints) {
+      cb(err, endpoints);
+    });
+  };
+
 
   // Helper function to apply a differential set of items to a base set.
   // This is needed when reading our base/diff storage format.
   //
-  function applyDiffItems(baseItems, diffItems) { 
+  function applyDiffItems(baseItems, diffItems) {
     for (var id in diffItems) {
       if (diffItems.hasOwnProperty(id)) {
         baseItems[id] = diffItems[id];
-      } 
+      }
     }
     return baseItems;
   }

--- a/lib/syncstore.js
+++ b/lib/syncstore.js
@@ -104,6 +104,7 @@
  */
 
 const async = require('async');
+const request = require('request');
 const Hapi = require('hapi');
 const kvstore = require('./kvstore');
 
@@ -340,6 +341,16 @@ module.exports.connect = function connect(options, cb) {
               return;
             }
 
+            // asynchronously notify each endpoint of the version update
+            getEndpoints(userid, function(err, endpoints) {
+              if (!endpoints || err) return;
+              Object.keys(endpoints.value).forEach(function(ep) {
+                request.put(ep, { form: { version: newVersion } }, function(err, res) {
+                  console.log('notified endpoint', ep, res.statusCode, err);
+                });
+              });
+            });
+
             // Success!  Return the updated version number to the caller.
             return cb(null, { version: newVersion });
           });
@@ -386,19 +397,19 @@ module.exports.connect = function connect(options, cb) {
   // Add a pushserver endpoint
   syncstore.addEndpoint = function(userid, endpoint, cb) {
     var infoKey = 'endpoints/' + userid;
-    kv.get(infoKey, function(err, endpoints) {
+    kv.get(infoKey, function(err, eps) {
+      var endpoints = {};
       if (err) return cb(err);
-      if (!endpoints) endpoints = {};
-      if (!endpoints[endpoint]) {
-        endpoints[endpoint] = +new Date();
-        kv.set(infoKey, endpoints, function(err) {
-          cb(err);
-        });
-      }
+      if (eps) endpoints = eps.value;
+
+      endpoints[endpoint] = +new Date();
+      kv.set(infoKey, endpoints, function(err) {
+        cb(err);
+      });
     });
   };
 
-  // Add a pushserver endpoint
+  // Delete a pushserver endpoint
   syncstore.deleteEndpoint = function(userid, endpoint, cb) {
     var infoKey = 'endpoints/' + userid;
     kv.get(infoKey, function(err, endpoints) {
@@ -415,12 +426,12 @@ module.exports.connect = function connect(options, cb) {
     });
   };
 
-  syncstore.getEndpoints = function(userid, cb) {
+  function getEndpoints (userid, cb) {
     var infoKey = 'endpoints/' + userid;
     kv.get(infoKey, function(err, endpoints) {
       cb(err, endpoints);
     });
-  };
+  }
 
 
   // Helper function to apply a differential set of items to a base set.

--- a/lib/syncstore.js
+++ b/lib/syncstore.js
@@ -395,35 +395,43 @@ module.exports.connect = function connect(options, cb) {
   };
 
   // Add a pushserver endpoint
-  syncstore.addEndpoint = function(userid, endpoint, cb) {
+  syncstore.addEndpoint = function(userid, endpoint, finalCb) {
     var infoKey = 'endpoints/' + userid;
-    kv.get(infoKey, function(err, eps) {
-      var endpoints = {};
-      if (err) return cb(err);
-      if (eps) endpoints = eps.value;
+    var fn = function(cb) {
+      kv.get(infoKey, function(err, eps) {
+        var endpoints = {};
+        if (err) return cb(err);
+        if (eps) endpoints = eps.value;
 
-      endpoints[endpoint] = +new Date();
-      var casid = eps ? eps.casid : null;
-      var fn = kv.cas.bind(kv, infoKey, endpoints, casid);
-      retryLoop(fn, 10, cb);
-    });
+        endpoints[endpoint] = +new Date();
+        var casid = eps ? eps.casid : null;
+        kv.cas(infoKey, endpoints, casid,  function(err) {
+          cb(err);
+        });
+      });
+    };
+    retryLoop(fn, 10, finalCb);
   };
 
   // Delete a pushserver endpoint
-  syncstore.deleteEndpoint = function(userid, endpoint, cb) {
+  syncstore.deleteEndpoint = function(userid, endpoint, finalCb) {
     var infoKey = 'endpoints/' + userid;
-    kv.get(infoKey, function(err, endpoints) {
-      if (err) return cb(err);
+    var fn = function(cb) {
+      kv.get(infoKey, function(err, endpoints) {
+        if (err) return cb(err);
 
-      if (endpoints && endpoints.value[endpoint]) {
-        delete endpoints.value[endpoint];
-        var casid = endpoints ? endpoints.casid : null;
-        var fn = kv.cas.bind(kv, infoKey, endpoints.value, casid);
-        retryLoop(fn, 10, cb);
-      } else {
-        cb('syncstore.unknownEndpoint');
-      }
-    });
+        if (endpoints && endpoints.value[endpoint]) {
+          delete endpoints.value[endpoint];
+          var casid = endpoints ? endpoints.casid : null;
+          kv.cas(infoKey, endpoints.value, casid, function(err) {
+            cb(err);
+          });
+        } else {
+          cb('syncstore.unknownEndpoint');
+        }
+      });
+    };
+    retryLoop(fn, 10, finalCb);
   };
 
   function getEndpoints (userid, cb) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "awsbox": "0.4.4",
     "awsboxen": "0.1.0",
     "convict": "0.1.x",
-    "async": "0.2.5"
+    "async": "0.2.5",
+    "request": "2.14.0"
   },
   "optionalDependencies": {
     "mysql": "0.9.5"
@@ -27,6 +28,6 @@
   "devDependencies": {
     "mocha": "1.8.1",
     "jshint": "0.9.1",
-    "request": "2.14.0"
+    "nock": "0.17.x"
   }
 }

--- a/routes/endpoint.js
+++ b/routes/endpoint.js
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const Hapi = require('hapi');
+const config = require('../lib/config.js');
+const syncstore = require('../lib/syncstore.js');
+const prereqs = require('../lib/prereqs.js');
+
+const store = syncstore.connect();
+
+exports.routes = [
+  {
+    method: 'POST',
+    path: '/{userid}/endpoint',
+    handler: addEndpoint,
+    config: {
+      description: 'Add a push notification endpoint',
+      pre: [prereqs.checkUserId],
+      payload: 'parse'
+    }
+  },
+  {
+    method: 'DELETE',
+    path: '/{userid}/endpoint',
+    handler: deleteEndpoint,
+    config: {
+      description: 'Remove a push notification endpoint',
+      pre: [prereqs.checkUserId],
+      payload: 'parse'
+    }
+  }
+];
+
+function addEndpoint(request) {
+  var userid = request.params.userid;
+  var endpoint = request.payload.endpoint;
+
+  store.addEndpoint(userid, endpoint, function(err) {
+    if (err) return request.reply(Hapi.Error.internal(err));
+    var response = new Hapi.Response.Raw(request).code(204);
+    return request.reply(response);
+  });
+}
+
+function deleteEndpoint(request) {
+  var userid = request.params.userid;
+  var endpoint = request.payload.endpoint;
+
+  store.deleteEndpoint(userid, endpoint, function(err) {
+    if (err) return request.reply(Hapi.Error.internal(err));
+    var response = new Hapi.Response.Raw(request).code(204);
+    return request.reply(response);
+  });
+}

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,6 +1,7 @@
 var heartbeat = require('./heartbeat.js');
 var auth = require('./token-auth.js');
 var syncstore = require('./syncstore.js');
+var endpoint = require('./endpoint.js');
 
 var routes = [
     {
@@ -17,7 +18,8 @@ var routes = [
   .concat(
     heartbeat.routes,
     auth.routes,
-    syncstore.routes
+    syncstore.routes,
+    endpoint.routes
   );
 
 // Define the route

--- a/test/integration/endpoint.js
+++ b/test/integration/endpoint.js
@@ -1,9 +1,15 @@
 const assert = require('assert');
 const helpers = require('../helpers');
+const nock = require('nock');
+
 
 const server = helpers.server;
 
-const TEST_TOKEN = 'faketoken';
+const TEST_TOKEN = 'fakepushtoken';
+
+const PUSH_HOST = 'http://pushserver.org';
+const ENDPOINT_1 = '/notify/testendpoint1';
+const ENDPOINT_2 = '/notify/testendpoint2';
 
 describe('syncstore web api', function() {
 
@@ -15,19 +21,72 @@ describe('syncstore web api', function() {
 
   it('allows creation of a new endpoint', function(done) {
     testClient.makeRequest('POST', '/endpoint', {
-      payload: { endpoint: 'http://pushserver.org/notify/testendpoint' },
+      payload: { endpoint: PUSH_HOST + ENDPOINT_1},
     }, function(res) {
       assert.equal(res.statusCode, 204);
       done();
     });
   });
 
-  it('allows deletion of an endpoint', function(done) {
-    testClient.makeRequest('DELETE', '/endpoint', {
-      payload: { endpoint: 'http://pushserver.org/notify/testendpoint' }
+  it('allows creation of a second endpoint', function(done) {
+    testClient.makeRequest('POST', '/endpoint', {
+      payload: { endpoint: PUSH_HOST + ENDPOINT_2},
     }, function(res) {
       assert.equal(res.statusCode, 204);
       done();
+    });
+  });
+
+  it('sends new version to endpoint after updates', function(done) {
+
+    // set up a mock server at the endpoint url
+    // check to make sure it receives a put request with version 1
+    nock(PUSH_HOST)
+      .put(ENDPOINT_1)
+      .reply(200, function (uri, body) {
+        assert.equal(body, 'version=1');
+        return;
+      })
+      .put(ENDPOINT_2)
+      .reply(200, function (uri, body) {
+        assert.equal(body, 'version=1');
+        done();
+        return;
+      });
+
+    testClient.makeRequest('POST', '/storage/col1', {
+      payload: [{ id: 'one', payload: 'TESTONE' }],
+    }, function(res) {
+      assert.equal(res.statusCode, 200);
+    });
+  });
+
+  it('allows deletion of an endpoint', function(done) {
+    testClient.makeRequest('DELETE', '/endpoint', {
+      payload: { endpoint: PUSH_HOST + ENDPOINT_1}
+    }, function(res) {
+      assert.equal(res.statusCode, 204);
+      done();
+    });
+  });
+
+  it('allows deletion of a second endpoint', function(done) {
+    testClient.makeRequest('DELETE', '/endpoint', {
+      payload: { endpoint: PUSH_HOST + ENDPOINT_2}
+    }, function(res) {
+      assert.equal(res.statusCode, 204);
+      done();
+    });
+  });
+
+  it('lets me delete all of my data', function(done) {
+    testClient.makeRequest('DELETE', '', function(res) {
+      assert.equal(res.statusCode, 204);
+      testClient.makeRequest('GET', '/info/collections', function(res) {
+        assert.equal(res.statusCode, 200);
+        assert.equal(res.result.version, 0);
+        done();
+      });
     });
   });
 

--- a/test/integration/endpoint.js
+++ b/test/integration/endpoint.js
@@ -1,0 +1,34 @@
+const assert = require('assert');
+const helpers = require('../helpers');
+
+const server = helpers.server;
+
+const TEST_TOKEN = 'faketoken';
+
+describe('syncstore web api', function() {
+
+  // Test client that includes auth information by default.
+  var testClient = new helpers.TestClient({
+    basePath: '/' + TEST_TOKEN,
+    defaultHeaders: { Authorization: TEST_TOKEN },
+  });
+
+  it('allows creation of a new endpoint', function(done) {
+    testClient.makeRequest('POST', '/endpoint', {
+      payload: { endpoint: 'http://pushserver.org/notify/testendpoint' },
+    }, function(res) {
+      assert.equal(res.statusCode, 204);
+      done();
+    });
+  });
+
+  it('allows deletion of an endpoint', function(done) {
+    testClient.makeRequest('DELETE', '/endpoint', {
+      payload: { endpoint: 'http://pushserver.org/notify/testendpoint' }
+    }, function(res) {
+      assert.equal(res.statusCode, 204);
+      done();
+    });
+  });
+
+});


### PR DESCRIPTION
This addresses #62 and #63.

It doesn't do any garbage collection currently, but does store timestamps for when the endpoint was last set, in case we want to support it in the future.

@rfk r?
