### PR TITLE
use firefox.persona.org as the persona verifier

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -23,13 +23,13 @@ var conf = module.exports = convict({
   persona_url: {
     doc: "Persona service",
     format: "url",
-    default: "https://picl.personatest.org",
+    default: "https://firefoxos.persona.org",
     env: 'PERSONA_URL'
   },
   verifier_url: {
     doc: "Service used to verify Persona assertions",
     format: "url",
-    default: "https://picl.personatest.org/verify",
+    default: "https://firefoxos.persona.org/verify",
     env: 'VERIFIER_URL'
   },
   kvstore: {


### PR DESCRIPTION
The old instance of Persona has died. Let's switch to the properly maintained https://firefox.persona.org.
