### PR TITLE
fixes #68: skip testing of endpoints on remote servers, since we cannot ...

### DIFF
--- a/test/integration/endpoint.js
+++ b/test/integration/endpoint.js
@@ -38,6 +38,9 @@ describe('syncstore web api', function() {
   });
 
   it('sends new version to endpoint after updates', function(done) {
+    // Skip this test for remote servers since we cannot easily
+    // intercept requests to the remote push sever it communicates with
+    if (process.env.TEST_REMOTE) return done();
 
     // set up a mock server at the endpoint url
     // check to make sure it receives a put request with version 1


### PR DESCRIPTION
...reliably detect interactions with the push server it is using.

Fixes #68
