### PR TITLE
Updating dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "common server bits for myfirefox",
   "main": "index.js",
   "scripts": {
-    "test": "NODE_ENV=test ./node_modules/.bin/mocha -R spec --recursive --timeout 15000 --ignore-leaks",
+    "test": "NODE_ENV=test ./node_modules/.bin/mocha -R spec --recursive --timeout 15000",
     "start": "NODE_ENV=local node index.js",
     "loadtest": "node loadtest/run.js"
   },
@@ -26,8 +26,8 @@
     "mysql": "0.9.5"
   },
   "devDependencies": {
-    "mocha": "1.8.1",
+    "mocha": "1.9.0",
     "jshint": "0.9.1",
-    "nock": "0.17.x"
+    "nock": "0.18.x"
   }
 }


### PR DESCRIPTION
Updating mocha to the latest version. 

Removed `--ignore-leaks`, as of mocha 1.9+ it "does not check for global variable leaks by default, so the '--ignore-leaks' option has been replaced with '--check-leaks'."

Updated nock, all tests passing locally with a mysql and a memory server.
