### PR TITLE
Enable travis tests for mysql and cassandra backends.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,21 @@ notifications:
     skip_join: false
 
 env:
-  - KVSTORE_BACKEND=memory
+  - KVSTORE_BACKEND=memory SYNCSTORE_BACKEND=kvstore
+  - KVSTORE_BACKEND=mysql SYNCSTORE_BACKEND=kvstore
+  - SYNCSTORE_BACKEND=mysql
+  - SYNCSTORE_BACKEND=cassandra
 
-before_script:
-  - "mysql -e 'DROP DATABASE IF EXISTS test;'"
-  - "mysql -e 'CREATE DATABASE test;'" 
+services:
+  - mysql
+  - memcached
+  # travis cassandra doesn't start properly
+  # https://github.com/travis-ci/travis-ci/issues/840
+  #-cassandra
+
+
+# workaround to get cassandra running
+# from https://github.com/travis-ci/travis-ci/issues/1053#issuecomment-16851963
+before_install:
+  - sudo sh -c "echo 'JVM_OPTS=\"\${JVM_OPTS} -Djava.net.preferIPv4Stack=false\"' >> /usr/local/cassandra/conf/cassandra-env.sh"
+  - sudo service cassandra start

--- a/lib/syncstore/cassandra.js
+++ b/lib/syncstore/cassandra.js
@@ -110,7 +110,29 @@ function Store(options) {
       self.pool.on('error', function(err) {
         self.emit('error', err);
       });
-      self.pool.connect(cb);
+      self.pool.connect(function(err) {
+        // This might fail if the keyspace does not exist.
+        // We can create it and try again.
+        if (!err) return cb();
+        if (!options.create_schema) return cb(err);
+        var missingKeyspaceRE = /Could Not Connect To Any Nodes/;
+        if (!missingKeyspaceRE.exec(err.toString())) return cb(err);
+        // Use a fresh pool for the keyspace creation.
+        // There may be a way to reuse self.pool, but it escapes me...
+        var createOptions = {hosts: options.hosts};
+        var createPool = new helenus.ConnectionPool(createOptions);
+        createPool.once('error', cb);
+        createPool.connect(function(err) {
+          if (err) return cb(err);
+          createPool.createKeyspace(options.keyspace, function(err) {
+            if (err) return cb(err);
+            createPool.once('close', function() {
+              self.pool.connect(cb);
+            });
+            createPool.close();
+          });
+        });
+      });
     },
 
     // Create the necessary tables, if they don't exist.
@@ -146,7 +168,10 @@ function Store(options) {
 
 Store.prototype.close = function close(cb) {
   this.memcached.end();
-  this.client.close(cb);
+  this.client.once('close', function() {
+    cb();
+  });
+  this.client.close();
 };
 
 

--- a/test/integration/endpoint.js
+++ b/test/integration/endpoint.js
@@ -11,7 +11,7 @@ const PUSH_HOST = 'http://pushserver.org';
 const ENDPOINT_1 = '/notify/testendpoint1';
 const ENDPOINT_2 = '/notify/testendpoint2';
 
-describe('syncstore web api', function() {
+describe('syncstore notifications web api', function() {
 
   // Test client that includes auth information by default.
   var testClient = new helpers.TestClient({


### PR DESCRIPTION
This tweaks the travis config to get mysql and cassandra running, and updates the cassandra backend to automatically create its keyspace.  Let's see if travis will reliably pass this PR...
