### PR TITLE
Custom backend loadtests

### DIFF
--- a/.awsboxen/Profiles/loadtest-cassandra/Boxen.json
+++ b/.awsboxen/Profiles/loadtest-cassandra/Boxen.json
@@ -1,0 +1,18 @@
+{
+  "AWSBox": {
+    "Properties": {
+      "hooks": null,
+      "env": {
+        "SYNCSTORE_BACKEND": "cassandra"
+      }
+    }
+  },
+
+  "CassandraServer": {
+    "Type": "AWSBoxen::BuildScript",
+    "Properties": {
+      "BaseAMI": "ami-05355a6c",
+      "BuildScript": "scripts/build_cassandra_node.sh"
+    }
+  }
+}

--- a/.awsboxen/Profiles/loadtest-cassandra/Resources.json
+++ b/.awsboxen/Profiles/loadtest-cassandra/Resources.json
@@ -1,0 +1,54 @@
+{
+
+  "WebServer": {
+    "Properties": {
+      "InstanceType" : "m1.large",
+      "UserData": { "Fn::Base64": { "Fn::Join": [ "\n", [
+        "#!/bin/sh",
+        "set -e -x",
+        "cat << EOF > /home/app/aws.json",
+        "{",
+        "  \"syncstore\": {",
+        "    \"backend\": \"cassandra\"",
+        "  },",
+        "  \"cassandra\": {",
+        "    \"hosts\":",
+        {"Fn::Join": ["", ["[\"", {"Fn::GetAtt": ["CassandraServer", "PublicDnsName"]}, ":9160\"]"]]},
+        "  },",
+        "  \"memcached\": {",
+        "    \"hosts\":",
+        {"Fn::Join": ["", ["\"", {"Fn::GetAtt": ["CassandraServer", "PublicDnsName"]}, ":11211\""]]},
+        "  }",
+        "}",
+        "EOF",
+        ""
+      ]]}}
+    }
+  },
+
+  "CassandraServer": {
+    "Type" : "AWS::EC2::Instance",
+    "Properties" : {
+      "InstanceType" : "m1.large",
+      "ImageId": { "Ref": "CassandraServerAMI" },
+      "KeyName": { "Ref": "AWSBoxDeployKey" },
+      "SecurityGroups": [ {"Ref": "CassandraServerSecurityGroup"} ]
+    }
+  },
+
+  "CassandraServerSecurityGroup": {
+    "Type" : "AWS::EC2::SecurityGroup",
+    "Properties" : {
+      "GroupDescription" : "Enable Cassandra, Memcached and SSH access",
+      "SecurityGroupIngress" : [
+        {"IpProtocol" : "tcp",
+         "FromPort" : "9160", "ToPort" : "9160", "CidrIp" : "0.0.0.0/0"},
+        {"IpProtocol" : "tcp",
+         "FromPort" : "11211", "ToPort" : "11211", "CidrIp" : "0.0.0.0/0"},
+        {"IpProtocol" : "tcp",
+         "FromPort" : "22", "ToPort" : "22", "CidrIp" : "0.0.0.0/0"}
+      ]
+    }
+  }
+
+}

--- a/.awsboxen/Profiles/loadtest-mysql/Boxen.json
+++ b/.awsboxen/Profiles/loadtest-mysql/Boxen.json
@@ -1,0 +1,18 @@
+{
+  "AWSBox": {
+    "Properties": {
+      "hooks": null,
+      "env": {
+        "SYNCSTORE_BACKEND": "mysql"
+      }
+    }
+  },
+
+  "MysqlServer": {
+    "Type": "AWSBoxen::BuildScript",
+    "Properties": {
+      "BaseAMI": "ami-05355a6c",
+      "BuildScript": "scripts/build_mysql_node.sh"
+    }
+  }
+}

--- a/.awsboxen/Profiles/loadtest-mysql/Resources.json
+++ b/.awsboxen/Profiles/loadtest-mysql/Resources.json
@@ -1,0 +1,47 @@
+{
+
+  "WebServer": {
+    "Properties": {
+      "InstanceType" : "m1.large",
+      "UserData": { "Fn::Base64": { "Fn::Join": [ "\n", [
+        "#!/bin/sh",
+        "set -e -x",
+        "cat << EOF > /home/app/aws.json",
+        "{",
+        "  \"mysql\": {",
+        "    \"user\": \"picl\",",
+        "    \"password\": \"piclmesoftly\",",
+        "    \"host\":",
+        {"Fn::Join": ["", ["\"", {"Fn::GetAtt": ["MysqlServer", "PublicDnsName"]}, "\""]]},
+        "  }",
+        "}",
+        "EOF",
+        ""
+      ]]}}
+    }
+  },
+
+  "MysqlServer": {
+    "Type" : "AWS::EC2::Instance",
+    "Properties" : {
+      "InstanceType" : "m1.large",
+      "ImageId": { "Ref": "MysqlServerAMI" },
+      "KeyName": { "Ref": "AWSBoxDeployKey" },
+      "SecurityGroups": [ {"Ref": "MysqlServerSecurityGroup"} ]
+    }
+  },
+
+  "MysqlServerSecurityGroup": {
+    "Type" : "AWS::EC2::SecurityGroup",
+    "Properties" : {
+      "GroupDescription" : "Enable MySQL and SSH access",
+      "SecurityGroupIngress" : [
+        {"IpProtocol" : "tcp",
+         "FromPort" : "3306", "ToPort" : "3306", "CidrIp" : "0.0.0.0/0"},
+        {"IpProtocol" : "tcp",
+         "FromPort" : "22", "ToPort" : "22", "CidrIp" : "0.0.0.0/0"}
+      ]
+    }
+  }
+
+}

--- a/loadtest/StressTest.conf
+++ b/loadtest/StressTest.conf
@@ -1,7 +1,7 @@
 [main]
 title=PICL Server Funkload test
 description=Simple PICL Server Test
-url=http://loadtest.storage.profileinthecloud.net/
+url=http://loadtest.storage.profileinthecloud.net
 
 [ftest]
 log_to = console file
@@ -12,7 +12,7 @@ sleep_time_min = 0
 sleep_time_max = 0
 
 [bench]
-cycles = 50:100:150:200
+cycles = 10:30:50:70:100
 duration = 60
 startup_delay = 0.05
 sleep_time = 0.01

--- a/loadtest/run.js
+++ b/loadtest/run.js
@@ -22,6 +22,9 @@ const async = require('async');
 const assert = require('assert');
 const child_process = require('child_process');
 
+const AWSBOX = require.resolve('awsbox/awsbox.js');
+const AWSBOXEN = require.resolve('awsboxen/lib/awsboxen.js');
+
 // The SHA1 of the current git commit is used throughout for naming purposes.
 var currentCommit = null;
 var testName = null;
@@ -64,7 +67,7 @@ function(cb) {
   // Spawn awsboxen as a sub-process.
   // We capture stdout trough a pipe, but also buffer it in
   // memory so that we can grab info out of it.
-  var p = child_process.spawn('awsboxen',
+  var p = child_process.spawn(AWSBOXEN,
                          ['deploy', '-p' + serverStackProfile, serverStackId],
                          {'stdio': [0, 'pipe', 2]});
   p.stdout.on('data', function(d) {
@@ -91,7 +94,7 @@ function(cb) {
   // Spawn awsbox as a sub-process.
   // We capture stdout trough a pipe, but also buffer it in
   // memory so that we can grab info out of it.
-  var p = child_process.spawn('awsbox',
+  var p = child_process.spawn(AWSBOX,
                               ['create', '-n', serverName, '-t', 'm1.large'],
                               {'stdio': [0, 'pipe', 2]});
   p.stdout.on('data', function(d) {
@@ -171,7 +174,7 @@ function(cb) {
     function(cb) {
       if (!clientInstanceId) return cb();
       console.log("cleaning up client VM...");
-      var p = child_process.spawn('awsbox',
+      var p = child_process.spawn(AWSBOX,
                                   ['destroy', testName + '-client'],
                                   {'stdio': 'inherit'});
       p.on('exit', function(code, signal) {
@@ -182,7 +185,7 @@ function(cb) {
     function(cb) {
       if (!serverStackId) return cb();
       console.log("cleaning up server stack...");
-      var p = child_process.spawn('awsboxen',
+      var p = child_process.spawn(AWSBOXEN,
                                   ['teardown', serverStackId],
                                   {'stdio': 'inherit'});
       p.on('exit', function(code, signal) {

--- a/loadtest/stress.py
+++ b/loadtest/stress.py
@@ -20,12 +20,6 @@ class StressTest(FunkLoadTestCase):
         if not self.server_url.endswith("/"):
             self.server_url += "/"
 
-    def test_hello_world(self):
-        self.setOkCodes([200])
-        response = self.get(self.server_url + "/hello")
-        self.assertTrue(response.body != '')
-        self.assertEquals(json.loads(response.body)["greeting"], "it works")
-
     def test_syncstore_read_and_write(self):
         COLLECTIONS = ["history", "bookmarks", "tabs", "passwords"]
         auth_token = uuid.uuid4().hex

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "hapi": "0.14.2",
     "joi": "0.1.1",
-    "awsbox": "0.4.4",
+    "awsbox": "0.4.5",
     "awsboxen": "0.1.0",
     "convict": "0.1.x",
     "async": "0.2.5",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "hapi": "0.14.2",
     "joi": "0.1.1",
     "awsbox": "0.4.5",
-    "awsboxen": "0.1.0",
+    "awsboxen": "0.1.1",
     "convict": "0.1.x",
     "async": "0.2.5",
     "request": "2.14.0"

--- a/scripts/aws/post_create.sh
+++ b/scripts/aws/post_create.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 echo "Setting up mysql"
 
+sudo yum --assumeyes install mysql mysql-server
+
 sudo /sbin/chkconfig mysqld on
 sudo /sbin/service mysqld start
 echo "CREATE USER 'picl'@'localhost';" | mysql -u root

--- a/scripts/build_cassandra_node.sh
+++ b/scripts/build_cassandra_node.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+#
+# Build a cassandra-based storage node for picl-server.
+
+set -e
+
+YUM="yum --assumeyes"
+
+# Install cassandra from datastax community edition repos.
+
+cat << EOF > /etc/yum.repos.d/datastax.repo
+[datastax]
+name= DataStax Repo for Apache Cassandra
+baseurl=http://rpm.datastax.com/community
+enabled=1
+gpgcheck=0
+EOF
+
+$YUM update
+$YUM install dsc12
+
+# Hack default config to work with OpenJDK.
+# It needs a bigger stack size, or it segfaults.
+#
+#   https://issues.apache.org/jira/browse/CASSANDRA-2441
+
+perl -pi -e 's/Xss180k/Xss280k/g' /etc/cassandra/conf/cassandra-env.sh
+
+# Make cassandra start on startup.
+
+perl -pi -e 's/rpc_address: localhost/rpc_address: 0.0.0.0/g' /etc/cassandra/conf/cassandra.yaml
+
+/sbin/chkconfig cassandra on
+/sbin/service cassandra start
+
+# Install memcached and start it on startup.
+
+$YUM install memcached
+
+/sbin/chkconfig memcached on
+/sbin/service memcached start

--- a/scripts/build_mysql_node.sh
+++ b/scripts/build_mysql_node.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+# Build a MySQL-based storage node for picl-server.
+
+set -e
+
+YUM="yum --assumeyes"
+
+$YUM update
+$YUM install mysql mysql-server
+
+/sbin/chkconfig mysqld on
+/sbin/service mysqld start
+
+echo "CREATE USER 'picl' IDENTIFIED BY 'piclmesoftly';" | mysql -u root
+echo "CREATE DATABASE picl;" | mysql -u root
+echo "GRANT ALL ON picl.* TO 'picl';" | mysql -u root
+


### PR DESCRIPTION
This PR adds deployment profiles "loadtest-mysql" and "loadtest-cassandra", for easily trying out different backends.  They're currently very naive and bare-bones, but we can iterate on them with this infra in place.  They require awsboxen 0.1.1, which lets you build AMIs from a shell script.

The loadtest/run.js script is updated to use these profiles for its deployment, allowing you to switch between them with an environment variable.  Running::

```
SYNCSTORE_BACKEND=mysql ./loadtest/run.js
```

Will deploy and test the mysql-backed setup, while::

```
SYNCSTORE_BACKEND=cassandra ./loadtest/run.js
```

Will deploy and test the cassandra-backed setup.

@dannycoates r?
